### PR TITLE
Fix New RPC Session Request

### DIFF
--- a/SBRW.Launcher.Core.Discord/RPC_/Presence_Launcher.cs
+++ b/SBRW.Launcher.Core.Discord/RPC_/Presence_Launcher.cs
@@ -494,9 +494,16 @@ namespace SBRW.Launcher.Core.Discord.RPC_
             {
                 if (!Presence_Settings.Disable_RPC_Startup)
                 {
+                    bool Valid_RPC = long.TryParse(RPC_ID, out long App_ID_Checked);
+
+                    if (Valid_RPC || Boot_Or_Reboot)
+                    {
+                        Stop("Update");
+                    }
+
                     Log.Core("DISCORD: Initializing Rich Presence Core" + (!Boot_Or_Reboot ? " For Server" : ""));
 
-                    Client = new DiscordRpcClient(long.TryParse(RPC_ID, out long App_ID_Checked) ? App_ID_Checked.ToString() : "576154452348633108");
+                    Client = new DiscordRpcClient(Valid_RPC ? App_ID_Checked.ToString() : "576154452348633108");
                     Client.OnReady += (sender, e) =>
                     {
                         Log.Info("DISCORD: Discord ready. Detected user: " + e.User.Username + ". Discord version: " + e.Version);

--- a/SBRW.Launcher.Core.Discord/SBRW.Launcher.Core.Discord.csproj
+++ b/SBRW.Launcher.Core.Discord/SBRW.Launcher.Core.Discord.csproj
@@ -7,7 +7,7 @@
     <Authors>Soapbox Race World - Launcher Division</Authors>
     <Company>Soapbox Race World</Company>
     <PackageProjectUrl>https://github.com/DavidCarbon-SBRW/SBRW.Launcher.Core.Discord</PackageProjectUrl>
-    <Version>0.0.21</Version>
+    <Version>0.0.22</Version>
     <Description>A Game Launchers Discord RPC Library built within the .NET Standard Framework</Description>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Discord, RPC</PackageTags>


### PR DESCRIPTION
Fixed:
- If a New RPC ID or Reboot/Boot Flag is True, session will now correctly start a new RPC